### PR TITLE
Enable support for instance IAM role

### DIFF
--- a/aws-profile
+++ b/aws-profile
@@ -25,7 +25,6 @@
 #     output = json
 #     region = us-east-1
 #     role_arn = arn:aws:iam::XXXXXXXXXXXX:role/Admins
-#     source_profile =  source-profile-name
 #     mfa_serial = arn:aws:iam::XXXXXXXXXXXX:mfa/XXL@XXXXXXXXX.de
 
 # TODO
@@ -95,16 +94,9 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn or source_profile." % profile
+    if 'role_arn' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn." % profile
         quit(3)
-
-    source = profiles[profile]['source_profile']
-
-    # Verify the source profile is correctly setup
-    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
-        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
-        quit(4)
 
     return profiles[profile]
 
@@ -154,8 +146,7 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    profiledSession = boto3.Session( profile_name=config['source_profile'] )
-    sts_connection = profiledSession.client('sts')
+    sts_connection = boto3.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -165,7 +156,6 @@ def get_creds_from_sts(key_path):
     if not globalQuiet:
        print("=======================================================")
        print("=> Assuming role .... : %s " % config['role_arn'])
-       print("==> Source Profile .. : %s " % config['source_profile']  )
 
        if not skipmfa:
            print("==> MFA Serial ...... : %s " % config['mfa_serial']  )
@@ -265,3 +255,4 @@ if not globalQuiet:
    print("=======================================================")
 
 exit(os.WEXITSTATUS(command_status))
+

--- a/aws-profile
+++ b/aws-profile
@@ -25,6 +25,7 @@
 #     output = json
 #     region = us-east-1
 #     role_arn = arn:aws:iam::XXXXXXXXXXXX:role/Admins
+#     source_profile =  source-profile-name
 #     mfa_serial = arn:aws:iam::XXXXXXXXXXXX:mfa/XXL@XXXXXXXXX.de
 
 # TODO
@@ -94,9 +95,16 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn." % profile
+    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn or source_profile." % profile
         quit(3)
+
+    source = profiles[profile]['source_profile']
+
+    # Verify the source profile is correctly setup
+    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
+        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
+        quit(4)
 
     return profiles[profile]
 
@@ -146,7 +154,8 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    sts_connection = boto3.client('sts')
+    profiledSession = boto3.Session( profile_name=config['source_profile'] )
+    sts_connection = profiledSession.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -156,6 +165,7 @@ def get_creds_from_sts(key_path):
     if not globalQuiet:
        print("=======================================================")
        print("=> Assuming role .... : %s " % config['role_arn'])
+       print("==> Source Profile .. : %s " % config['source_profile']  )
 
        if not skipmfa:
            print("==> MFA Serial ...... : %s " % config['mfa_serial']  )
@@ -255,4 +265,3 @@ if not globalQuiet:
    print("=======================================================")
 
 exit(os.WEXITSTATUS(command_status))
-

--- a/aws-profile
+++ b/aws-profile
@@ -95,16 +95,9 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn or source_profile." % profile
+    if 'role_arn' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn." % profile
         quit(3)
-
-    source = profiles[profile]['source_profile']
-
-    # Verify the source profile is correctly setup
-    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
-        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
-        quit(4)
 
     return profiles[profile]
 
@@ -154,8 +147,8 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    profiledSession = boto3.Session( profile_name=config['source_profile'] )
-    sts_connection = profiledSession.client('sts')
+    session = boto3.Session( profile_name=config.get('source_profile') )
+    sts_connection = session.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -165,7 +158,8 @@ def get_creds_from_sts(key_path):
     if not globalQuiet:
        print("=======================================================")
        print("=> Assuming role .... : %s " % config['role_arn'])
-       print("==> Source Profile .. : %s " % config['source_profile']  )
+       print("==> Source Profile .. : %s " % config.get('source_profile') )
+
 
        if not skipmfa:
            print("==> MFA Serial ...... : %s " % config['mfa_serial']  )

--- a/aws-profile2
+++ b/aws-profile2
@@ -25,7 +25,6 @@
 #     output = json
 #     region = us-east-1
 #     role_arn = arn:aws:iam::XXXXXXXXXXXX:role/Admins
-#     source_profile =  source-profile-name
 #     mfa_serial = arn:aws:iam::XXXXXXXXXXXX:mfa/XXL@XXXXXXXXX.de
 
 # TODO
@@ -94,16 +93,9 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn or source_profile." % profile
+    if 'role_arn' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn." % profile
         quit(3)
-
-    source = profiles[profile]['source_profile']
-
-    # Verify the source profile is correctly setup
-    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
-        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
-        quit(4)
 
     return profiles[profile]
 
@@ -149,8 +141,7 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    profiledSession = boto3.Session( profile_name=config['source_profile'] )
-    sts_connection = profiledSession.client('sts')
+    sts_connection = boto3.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -159,7 +150,6 @@ def get_creds_from_sts(key_path):
 
     print("=======================================================")
     print("=> Assuming role .... : %s " % config['role_arn'])
-    print("==> Source Profile .. : %s " % config['source_profile']  )
 
     if not skipmfa:
         print("==> MFA Serial ...... : %s " % config['mfa_serial']  )

--- a/aws-profile2
+++ b/aws-profile2
@@ -25,6 +25,7 @@
 #     output = json
 #     region = us-east-1
 #     role_arn = arn:aws:iam::XXXXXXXXXXXX:role/Admins
+#     source_profile =  source-profile-name
 #     mfa_serial = arn:aws:iam::XXXXXXXXXXXX:mfa/XXL@XXXXXXXXX.de
 
 # TODO
@@ -93,9 +94,16 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn." % profile
+    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn or source_profile." % profile
         quit(3)
+
+    source = profiles[profile]['source_profile']
+
+    # Verify the source profile is correctly setup
+    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
+        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
+        quit(4)
 
     return profiles[profile]
 
@@ -141,7 +149,8 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    sts_connection = boto3.client('sts')
+    profiledSession = boto3.Session( profile_name=config['source_profile'] )
+    sts_connection = profiledSession.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -150,6 +159,7 @@ def get_creds_from_sts(key_path):
 
     print("=======================================================")
     print("=> Assuming role .... : %s " % config['role_arn'])
+    print("==> Source Profile .. : %s " % config['source_profile']  )
 
     if not skipmfa:
         print("==> MFA Serial ...... : %s " % config['mfa_serial']  )

--- a/aws-profile2
+++ b/aws-profile2
@@ -94,16 +94,9 @@ def read_config():
         print "Profile '%s' does not exist in the config file." % profile
         quit(2)
 
-    if 'role_arn' not in profiles[profile] or 'source_profile' not in profiles[profile]:
-        print "Profile '%s' does not have role_arn or source_profile." % profile
+    if 'role_arn' not in profiles[profile]:
+        print "Profile '%s' does not have role_arn." % profile
         quit(3)
-
-    source = profiles[profile]['source_profile']
-
-    # Verify the source profile is correctly setup
-    if 'aws_access_key_id' not in profiles[source] or 'aws_secret_access_key' not in profiles[source]:
-        print "Profile '%s' does not have the api keys necessary for assuming a role." % source
-        quit(4)
 
     return profiles[profile]
 
@@ -149,8 +142,8 @@ def get_creds_from_sts(key_path):
         else:
 	   mfaToken = mfakey.strip()
 
-    profiledSession = boto3.Session( profile_name=config['source_profile'] )
-    sts_connection = profiledSession.client('sts')
+    session = boto3.Session( profile_name=config.get('source_profile') )
+    sts_connection = session.client('sts')
 
     role_session_name = config.get('role_session_name')
 
@@ -159,7 +152,7 @@ def get_creds_from_sts(key_path):
 
     print("=======================================================")
     print("=> Assuming role .... : %s " % config['role_arn'])
-    print("==> Source Profile .. : %s " % config['source_profile']  )
+    print("==> Source Profile .. : %s " % config.get('source_profile')  )
 
     if not skipmfa:
         print("==> MFA Serial ...... : %s " % config['mfa_serial']  )


### PR DESCRIPTION
aws-profile script uses Boto3 aws client. And this client is supports loading credentials from instance metadata service. To enable this feature I dropped checks for config/source_profile and credentials/keys properties from aws-profile script.

As the result there is not need to load credentials manually on ec2 instances before using aws-profile.
And scripts like
curl http://169.254.169.254/latest/meta-data/iam/security-credentials/tf-jenkins-iam-role | ruby -e 'require "json";puts "[prod]";json = JSON.parse(ARGF.read);puts "aws_access_key_id = #{json["AccessKeyId"]}";puts "aws_secret_access_key = #{json["SecretAccessKey"]}";puts "aws_security_token = #{json["Token"]}"' > /root/.aws/credentials
aws-profile spock-dev aws s3 ls

would simplify to plain
aws-profile spock-dev aws s3 ls
