### PR TITLE
Prevent usage of almost expired tokens

### DIFF
--- a/aws-profile
+++ b/aws-profile
@@ -205,7 +205,7 @@ def get_creds_from_sts(key_path):
 def is_creds_valid(creds):
     end_time = parse(creds['expiration'])
     now = datetime.now(tzlocal())
-    return now <= end_time
+    return now + datetime.timedelta(minutes = 5) <= end_time
 
 
 def load_creds():


### PR DESCRIPTION
The problem with an almost expired token is that it gets expired in the middle of something. In my case, it expired in the middle of a terraform apply that caused corruption of the terraform state.
